### PR TITLE
Ensure that QueueBus.redis is always a Redis, not a RedisClient

### DIFF
--- a/lib/sidekiq_bus/adapter.rb
+++ b/lib/sidekiq_bus/adapter.rb
@@ -24,9 +24,8 @@ module QueueBus
         # Return a redis-rb Redis object even if Sidekiq returns
         # a RedisClient object.
         ::Sidekiq.redis do |conn|
-          binding.irb
           if conn.is_a?(::Redis)
-            return yield conn
+            return block.call(conn)
           end
 
           config = conn.config
@@ -39,7 +38,7 @@ module QueueBus
             password: config.password
           )
           begin
-            yield redis_instance
+            block.call(conn)
           ensure
             redis_instance.close
           end


### PR DESCRIPTION
Sidekiq 7 yields a RedisClient instance to Sidekiq.redis blocks, providing a lower-level API with some ugly footguns (e.g. integer return values to boolean methods, missing helper functions). For consistent behavior, bootstrap a redis-rb Redis object with the same connection info.

This is an extremely brute-force solution. We could alternatively allow an injectable Redis connection pool as a breaking change; but explore this unobtrusive option first.